### PR TITLE
Add support for gorilla/mux...

### DIFF
--- a/gorilla.go
+++ b/gorilla.go
@@ -3,6 +3,7 @@ package muxlist
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
@@ -32,7 +33,7 @@ func (m *GorillaMuxLister) Extract() ResultSet {
 		}
 
 		r[ROUTE_NAME] = route.GetName()
-		r[HTTP_METHODS] = "" //Currently unavailable for Gorilla Mux but there's a pending PR for this
+		r[HTTP_METHODS] = getMethodsAsString(route)
 
 		r[HANDLER_NAME] = GetHumanReadableNameForHandler(route.GetHandler())
 
@@ -41,6 +42,13 @@ func (m *GorillaMuxLister) Extract() ResultSet {
 	})
 
 	return result
+}
+
+func getMethodsAsString(route *mux.Route) string {
+	var routes []string
+	routes, _ = route.GetMethods()
+
+	return strings.Join(routes, ",")
 }
 
 func (m *GorillaMuxLister) List() string {

--- a/main.go
+++ b/main.go
@@ -27,5 +27,10 @@ func (lister *MuxLister) Table() {
 
 //Returns a human readable name for a http Handler
 func GetHumanReadableNameForHandler(h http.Handler) string {
-	return runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+	reflectValue := reflect.ValueOf(h)
+
+	if !reflectValue.IsValid() {
+		return "SUBROUTER"
+	}
+	return runtime.FuncForPC(reflectValue.Pointer()).Name()
 }


### PR DESCRIPTION
Subrouters and HTTP methods.

Prior to this change, when a subrouter was created, it would result in a
panic when trying to get thee function name.  Now, when a Subrouter is encountered, it will simply print
"SUBROUTER" for nte function name.

Additionally, if HTTP Methods are set for a route, it will now extract
the supported methods, "stringify" them, and add them to the display.